### PR TITLE
fixed typo in bun script example

### DIFF
--- a/examples/push.ts
+++ b/examples/push.ts
@@ -8,7 +8,7 @@
  * You'll see how push-based acquisition is faster because waiters are
  * notified immediately when permits are released, rather than polling.
  *
- * Run with: bun run examples/concurrent.ts
+ * Run with: bun run examples/push.ts
  * Requires REDIS_URL environment variable or local Redis at localhost:6379.
  */
 import { Console, Duration, Effect, Schedule } from "effect";


### PR DESCRIPTION
Small pr, but i was going through the examples and noticed (what i think to be) a typo! I attached 2 separate images of the example bun script you gave, one with the current `bun run examples/concurrent` and the other with `bun run examples/push.ts`

I assume you're busy with the bigger details of the project, so I figured I'd try to help out with a small detail :)