### PR TITLE
fix: do not retry on lock acquisition when its acquiredExternally

### DIFF
--- a/src/DistributedSemaphore.ts
+++ b/src/DistributedSemaphore.ts
@@ -406,7 +406,7 @@ export const make = (
           return maybeAcquired.value;
         }).pipe(
           Effect.retry({
-            while: (e) => e._tag === "LockNotAcquiredError",
+            while: (e) => e._tag === "LockNotAcquiredError" && !resolvedOptions.acquiredExternally,
             schedule: acquireRetryPolicy,
           })
         );


### PR DESCRIPTION
When `acquiredExternally` is passed as `true`, there's no reason to retry, as only the caller has a control over the given identifier.